### PR TITLE
Simplify gamma values and fix saving reliability

### DIFF
--- a/linux_steam_gamma.sh
+++ b/linux_steam_gamma.sh
@@ -32,17 +32,20 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-# Define the user gamma preference.
-echo "Enter a desktop gamma setting (e.g. '1.00:1.00:1.00') Press Enter to use this setting."
+# Define gamma preferences
+# Use default values on no input
+echo "Enter a desktop gamma setting (e.g. '1') Press Enter to use this setting."
 read -p "Desktop Gamma: " d_gamma
 
-echo "Enter your application gamma setting (e.g. '1.20:1.20:1.20'). Press Enter to use this setting."
+if [[ -z "$d_gamma" ]]; then
+    d_gamma="1"
+fi
+
+echo "Enter your application gamma setting (e.g. '1.20'). Press Enter to use this setting."
 read -p "Application Gamma: " a_gamma
 
-if [[ -z "$d_gamma" && -z "$a_gamma" ]]; then
-    # Use default gamma settings
-    d_gamma="1.00:1.00:1.00"
-    a_gamma="1.20:1.20:1.20"
+if [[ -z "$a_gamma" ]]; then
+    a_gamma="1.20"
 fi
 
 active_output=$(xrandr --query | awk '/ connected/ && / primary/ {print $1}')


### PR DESCRIPTION
Sort of 2 changes in 1, sorry about that already – let me know if I should split it up and I can.

- The taken gamma values are severely simplified from `1.00:1.00:1.00` and `1.20:1.20:1.20` to `1` and `1.20`. The default 1 being more human-readable and the more detailed 1.20 being a unified gamma value a game like Hunt would display. Initially I thought I would have to type these long values, but the short ones work.
- The algorithm for saving the gamma had an issue that when you took the default of one value (e.g. for desktop) but adjusted the one for the application, the one for desktop was not saved. The splitting up of the "use default gamma settings" if block seems to fix that according to my tests.

Hope that works @michaelmehl, and thanks for this tool! :) 